### PR TITLE
use "killall -s SIGINT" to hide Terminated message

### DIFF
--- a/audiobrowse.bash
+++ b/audiobrowse.bash
@@ -398,7 +398,7 @@ info_audio(){
 }
 
 kill_audio(){  
-  for p in ${players[@]}; do killall $(basename $p) &>/dev/null; done 
+  for p in ${players[@]}; do killall -s SIGINT $(basename $p) &>/dev/null; done 
 }
 
 play_audio(){


### PR DESCRIPTION
I just realised that the Stack Overflow [message](http://stackoverflow.com/a/13223242) I got the fix from was made by yourself :)
