### PR TITLE
swap j and k keys to match ranger's (and vim)

### DIFF
--- a/audiobrowse.bash
+++ b/audiobrowse.bash
@@ -291,9 +291,9 @@ lscd_base () {
         # Handle the input
         case "$input" in
             j|$'\e[A'|$'\e0A')
-                move -1;;
-            k|$'\e[B'|$'\e0B')
                 move 1;;
+            k|$'\e[B'|$'\e0B')
+                move -1;;
             $'\e[6'|$'\e[C'|$'\eOC')
                 move 10;;
             $'\e[5'|$'\e[D'|$'\eOD')


### PR DESCRIPTION
since audiobrowse states it takes inspiration from ranger and supports vim keys,
the mapping should match that of these software. the 'j' and 'k' keys were swapped
and this commit fixes that: j goes down and k goes up.